### PR TITLE
fix: form expectations did not match S3 forms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.0.1"
+version = "0.0.2"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
The expectations of `_id` and `_class` values is correct for database forms, but not S3 forms.
For S3 forms the content contains `id` and the form type is under `formtype` in the user metadata.

TIS21-4006