### PR TITLE
feat: export FormRs to NDW data lake

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -17,6 +17,10 @@
           "valueFrom": "/tis/trainee/ndw/${environment}/azure/tenant-id"
         },
         {
+          "name": "AZURE_DATA_LAKE_DIRECTORY",
+          "valueFrom": "/tis/trainee/ndw/${environment}/azure/data-lake-directory"
+        },
+        {
           "name": "AZURE_DATA_LAKE_NAME",
           "valueFrom": "/tis/trainee/ndw/${environment}/azure/data-lake-name"
         },

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -5,6 +5,22 @@
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-ndw-exporter:latest",
       "secrets": [
         {
+          "name": "AZURE_CLIENT_ID",
+          "valueFrom": "/tis/trainee/ndw/${environment}/azure/client-id"
+        },
+        {
+          "name": "AZURE_CLIENT_SECRET",
+          "valueFrom": "/tis/trainee/ndw/${environment}/azure/client-secret"
+        },
+        {
+          "name": "AZURE_TENANT_ID",
+          "valueFrom": "/tis/trainee/ndw/${environment}/azure/tenant-id"
+        },
+        {
+          "name": "AZURE_DATA_LAKE_NAME",
+          "valueFrom": "/tis/trainee/ndw/${environment}/azure/data-lake-name"
+        },
+        {
           "name": "SENTRY_DSN",
           "valueFrom": "tis-trainee-ndw-exporter-sentry-dsn"
         },

--- a/README.md
+++ b/README.md
@@ -23,16 +23,22 @@ TODO
 
 #### Environmental Variables
 
-| Name               | Description                                   | Default |
-|--------------------|-----------------------------------------------|---------|
-| **Logging:**       |                                               |         |
-| SENTRY_DSN         | A Sentry error monitoring Data Source Name.   |         |
-| SENTRY_ENVIRONMENT | The environment to log Sentry events against. | local   |
-| LOGGING_ROOT       | Root logging level.                           | INFO    |
-| LOGGING_EVENT      | NDW event logging level.                      | DEBUG   |
-| LOGGING_SERVICE    | NDW service logging level.                    | DEBUG   |
-| **Queues:**        |                                               |         |
-| NDW_FORM_QUEUE_URL | Queue to receive AWS S3 Form events.          |         |
+| Name                 | Description                                                 | Default |
+|----------------------|-------------------------------------------------------------|---------|
+| **Azure:**           |                                                             |
+| AZURE_CLIENT_ID      | The client ID for connecting to the NDW Azure instance.     |         |
+| AZURE_CLIENT_SECRET  | The client secret for connecting to the NDW Azure instance. |         |
+| AZURE_TENANT_ID      | The tenant ID for connecting to the NDW Azure instance.     |         |
+| AZURE_DATA_LAKE_NAME | The name of the NDW data lake to export to.                 | local   |
+| **Logging:**         |                                                             |         |
+| SENTRY_DSN           | A Sentry error monitoring Data Source Name.                 |         |
+| SENTRY_ENVIRONMENT   | The environment to log Sentry events against.               | local   |
+| LOGGING_ROOT         | Root logging level.                                         | INFO    |
+| LOGGING_EVENT        | NDW event logging level.                                    | DEBUG   |
+| LOGGING_SERVICE      | NDW service logging level.                                  | DEBUG   |
+| **Queues:**          |                                                             |         |
+| NDW_FORM_QUEUE_URL   | Queue to receive AWS S3 Form events.                        |         |
+
 
 ### Usage Examples
 TODO

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.0.2"
+version = "0.1.0"
 
 configurations {
   compileOnly {
@@ -25,7 +25,8 @@ repositories {
 dependencyManagement {
   imports {
     mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.3"
-    mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:2.4.4")
+    mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:2.4.4"
+    mavenBom "com.azure.spring:spring-cloud-azure-dependencies:4.6.0"
   }
 }
 
@@ -54,6 +55,9 @@ dependencies {
   // Amazon SQS
   implementation "io.awspring.cloud:spring-cloud-starter-aws"
   implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging"
+
+  implementation "com.azure.spring:spring-cloud-azure-starter"
+  implementation "com.azure:azure-storage-file-datalake"
 
   ext.testContainersVersion = "1.17.6"
   testImplementation "org.springframework.cloud:spring-cloud-starter"

--- a/src/main/java/uk/nhs/hee/tis/trainee/ndw/FormEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/ndw/FormEventDto.java
@@ -25,6 +25,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 
+/**
+ * A representation of a form event.
+ */
 @Data
 public class FormEventDto {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/ndw/config/AzureDataLakeConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/ndw/config/AzureDataLakeConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.ndw.config;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for connecting to an Azure data lake.
+ */
+@Configuration
+public class AzureDataLakeConfiguration {
+
+  /**
+   * Build a client for Azure data lake.
+   *
+   * @return The data lake client.
+   */
+  @Bean
+  public DataLakeFileSystemClient dataLakeFileSystemClient(TokenCredential credential,
+      @Value("${application.ndw.endpoint}") String endpoint) {
+    return new DataLakeFileSystemClientBuilder()
+        .credential(credential)
+        .endpoint(endpoint)
+        .buildClient();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/ndw/service/FormService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/ndw/service/FormService.java
@@ -23,8 +23,9 @@ package uk.nhs.hee.tis.trainee.ndw.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.azure.storage.file.datalake.DataLakeDirectoryClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import java.io.IOException;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -38,15 +39,17 @@ import uk.nhs.hee.tis.trainee.ndw.FormEventDto;
 @Service
 public class FormService {
 
-  private static final String FORM_ID_CONTENT_FIELD = "id";
   private static final String FORM_TYPE_METADATA_FIELD = "formtype";
+  private static final String NAME_METADATA_FIELD = "name";
+
+  private static final String DATA_LAKE_FORMR_ROOT = "formr/bronze";
 
   private final AmazonS3 amazonS3;
-  private final ObjectMapper mapper;
+  private final DataLakeFileSystemClient dataLakeClient;
 
-  FormService(AmazonS3 amazonS3, ObjectMapper mapper) {
+  FormService(AmazonS3 amazonS3, DataLakeFileSystemClient dataLakeClient) {
     this.amazonS3 = amazonS3;
-    this.mapper = mapper;
+    this.dataLakeClient = dataLakeClient;
   }
 
   /**
@@ -67,17 +70,53 @@ public class FormService {
       log.debug("Event version: {}\nLatest version: {}", event.getVersionId(), latestVersionId);
     }
 
-    JsonNode content = mapper.readTree(document.getObjectContent());
     Map<String, String> userMetadata = document.getObjectMetadata().getUserMetadata();
 
-    if (content.has(FORM_ID_CONTENT_FIELD) && userMetadata.containsKey(FORM_TYPE_METADATA_FIELD)) {
-      String formId = content.get(FORM_ID_CONTENT_FIELD).textValue();
+    if (userMetadata.containsKey(NAME_METADATA_FIELD) && userMetadata.containsKey(
+        FORM_TYPE_METADATA_FIELD)) {
+      String formName = userMetadata.get(NAME_METADATA_FIELD);
       String formType = userMetadata.get(FORM_TYPE_METADATA_FIELD);
-      log.info("Retrieved form id {} of type {}.", formId, formType);
+      log.info("Retrieved form {} of type {}.", formName, formType);
+
+      exportToDataLake(formName, formType, document);
     } else {
-      log.error("File {}/{} did not have the expected form structure.", event.getBucket(),
+      log.error("File {}/{} did not have the expected metadata.", event.getBucket(),
           event.getKey());
       throw new IOException("Unexpected document contents.");
+    }
+  }
+
+  /**
+   * Export a form to the data lake.
+   *
+   * @param formName The file name of the form.
+   * @param formType The form's type.
+   * @param document The S3 document to upload.
+   */
+  private void exportToDataLake(String formName, String formType, S3Object document) {
+    DataLakeDirectoryClient directoryClient;
+
+    switch (formType) {
+      case "formr-a" -> directoryClient = dataLakeClient
+          .getDirectoryClient(DATA_LAKE_FORMR_ROOT)
+          .createSubdirectoryIfNotExists("part-a");
+      case "formr-b" -> directoryClient = dataLakeClient
+          .getDirectoryClient(DATA_LAKE_FORMR_ROOT)
+          .createSubdirectoryIfNotExists("part-b");
+      default -> {
+        log.error("{} is not an exportable form type.", formType);
+        return;
+      }
+    }
+
+    try (S3ObjectInputStream content = document.getObjectContent()) {
+      log.info("Exporting form {} of type {}.", formName, formType);
+      directoryClient
+          .createFileIfNotExists(formName)
+          .upload(content, document.getObjectMetadata().getContentLength(), true);
+      log.info("Exported form {} of type {}.", formName, formType);
+    } catch (IOException e) {
+      log.warn("Unable to close stream for form {} of type {}.", formName, formType);
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/ndw/service/FormService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/ndw/service/FormService.java
@@ -29,6 +29,7 @@ import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import java.io.IOException;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.ndw.FormEventDto;
 
@@ -42,14 +43,16 @@ public class FormService {
   private static final String FORM_TYPE_METADATA_FIELD = "formtype";
   private static final String NAME_METADATA_FIELD = "name";
 
-  private static final String DATA_LAKE_FORMR_ROOT = "formr/bronze";
-
   private final AmazonS3 amazonS3;
   private final DataLakeFileSystemClient dataLakeClient;
 
-  FormService(AmazonS3 amazonS3, DataLakeFileSystemClient dataLakeClient) {
+  private final String getDataLakeFormrRoot;
+
+  FormService(AmazonS3 amazonS3, DataLakeFileSystemClient dataLakeClient,
+      @Value("${application.ndw.directory}") String directory) {
     this.amazonS3 = amazonS3;
     this.dataLakeClient = dataLakeClient;
+    this.getDataLakeFormrRoot = "formr/" + directory;
   }
 
   /**
@@ -98,10 +101,10 @@ public class FormService {
 
     switch (formType) {
       case "formr-a" -> directoryClient = dataLakeClient
-          .getDirectoryClient(DATA_LAKE_FORMR_ROOT)
+          .getDirectoryClient(getDataLakeFormrRoot)
           .createSubdirectoryIfNotExists("part-a");
       case "formr-b" -> directoryClient = dataLakeClient
-          .getDirectoryClient(DATA_LAKE_FORMR_ROOT)
+          .getDirectoryClient(getDataLakeFormrRoot)
           .createSubdirectoryIfNotExists("part-b");
       default -> {
         log.error("{} is not an exportable form type.", formType);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ application:
   aws:
     sqs:
       form: ${NDW_FORM_QUEUE_URL:}
+  ndw:
+    endpoint: https://${AZURE_DATA_LAKE_NAME:local}.dfs.core.windows.net/tis
 
 logging:
   level:
@@ -23,3 +25,12 @@ logging:
               ndw:
                 event: ${LOGGING_EVENT:DEBUG}
                 service: ${LOGGING_SERVICE:DEBUG}
+
+spring:
+  cloud:
+    azure:
+      credential:
+        client-id: ${AZURE_CLIENT_ID:}
+        client-secret: ${AZURE_CLIENT_SECRET:}
+      profile:
+        tenant-id: ${AZURE_TENANT_ID:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ application:
       form: ${NDW_FORM_QUEUE_URL:}
   ndw:
     endpoint: https://${AZURE_DATA_LAKE_NAME:local}.dfs.core.windows.net/tis
+    directory: ${AZURE_DATA_LAKE_DIRECTORY:dev}
 
 logging:
   level:

--- a/src/test/java/uk/nhs/hee/tis/trainee/ndw/config/AzureDataLakeConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/ndw/config/AzureDataLakeConfigurationTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.ndw.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AzureDataLakeConfigurationTest {
+
+  private AzureDataLakeConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new AzureDataLakeConfiguration();
+  }
+
+  @Test
+  void shouldSetClientAccountName() {
+    TokenCredential credential = mock(TokenCredential.class);
+    String endpoint = "https://test-lake.dfs.core.windows.net/test-fs";
+
+    DataLakeFileSystemClient client = configuration.dataLakeFileSystemClient(credential, endpoint);
+
+    assertThat("Unexpected account name.", client.getAccountName(), is("test-lake"));
+  }
+
+  @Test
+  void shouldSetClientFileSystemName() {
+    TokenCredential credential = mock(TokenCredential.class);
+    String endpoint = "https://test-lake.dfs.core.windows.net/test-fs";
+
+    DataLakeFileSystemClient client = configuration.dataLakeFileSystemClient(credential, endpoint);
+
+    assertThat("Unexpected file system name.", client.getFileSystemName(), is("test-fs"));
+  }
+}


### PR DESCRIPTION
Authenticate to the Azure data lake using the provided service
principal.
Export Form Rs to the NDW data lake when a form event is received.
The file contents will be overwritten with whatever contents is in S3.

TIS21-4327
TIS21-4328
TIS21-4329