### PR TITLE
fix: include upload length

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.1.0"
+version = "1.1.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/ndw/service/FormService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/ndw/service/FormService.java
@@ -130,7 +130,7 @@ public class FormService {
 
         directoryClient
             .createFileIfNotExists(formName)
-            .upload(cleanStream, 0L, true);
+            .upload(cleanStream, cleanedString.length(), true);
         log.info("Exported form {} of type {}.", formName, formType);
       } else {
         log.warn("Skipping empty form {} of type {}.", formName, formType);

--- a/src/test/java/uk/nhs/hee/tis/trainee/ndw/service/FormServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/ndw/service/FormServiceTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -223,11 +224,9 @@ class FormServiceTest {
     DataLakeFileClient fileClient = mock(DataLakeFileClient.class);
     when(directoryClient.createFileIfNotExists(FORM_NAME_VALUE)).thenReturn(fileClient);
 
-    byte[] contents = """
-        {
-          "field1": "value1"
-        }
-        """.getBytes(StandardCharsets.UTF_8);
+    String formContents = "{\"field1\":\"value1\"}";
+    byte[] contents = formContents.getBytes(StandardCharsets.UTF_8);
+    Long formContentsLength = (long) formContents.length();
 
     try (S3Object document = new S3Object();
         InputStream contentStream = new ByteArrayInputStream(contents)) {
@@ -239,7 +238,7 @@ class FormServiceTest {
       service.processFormEvent(formEvent);
 
       ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
-      verify(fileClient).upload(streamCaptor.capture(), eq(0L), eq(true));
+      verify(fileClient).upload(streamCaptor.capture(), eq(formContentsLength), eq(true));
 
       InputStream uploadedStream = streamCaptor.getValue();
       ObjectMapper mapper = new ObjectMapper();
@@ -365,7 +364,7 @@ class FormServiceTest {
       service.processFormEvent(formEvent);
 
       ArgumentCaptor<InputStream> streamCaptor = ArgumentCaptor.forClass(InputStream.class);
-      verify(fileClient).upload(streamCaptor.capture(), eq(0L), eq(true));
+      verify(fileClient).upload(streamCaptor.capture(), anyLong(), eq(true));
 
       InputStream uploadedStream = streamCaptor.getValue();
       ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Otherwise get errors like:
2023-06-07 15:08:02.074  INFO 1 --- [enerContainer-2] u.n.h.t.trainee.ndw.service.FormService  : Exporting form de0fc4af-77e7-4897-83f7-5d4a9fc278f7.json of type formr-a. 2023-06-07 15:08:02.473 ERROR 1 --- [enerContainer-2]
com.azure.storage.common.Utility         : Request body emitted 1162
bytes, more than the expected 0 bytes.
2023-06-07 15:08:02.666 ERROR 1 --- [enerContainer-2]
c.a.s.f.d.DataLakeFileAsyncClient        : Request body emitted 1162
bytes, more than the expected 0 bytes.
2023-06-07 15:08:02.680 ERROR 1 --- [enerContainer-2]
i.a.c.m.listener.QueueMessageHandler     : An exception occurred while
invoking the handler method
com.azure.core.exception.UnexpectedLengthException: Request body emitted
1162 bytes, more than the expected 0 bytes.
	at
	com.azure.storage.common.Utility.convertStreamToByteBuffer(Utility.java:217)
		at
		com.azure.storage.file.datalake.DataLakeFileAsyncClient.uploadWithResponse(DataLakeFileAsyncClient.java:625)

TIS21-4623