### PR TITLE
fix: container memory bump

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -70,5 +70,5 @@
   "taskRoleArn": "tis-trainee-ndw-exporter_task-role_${environment}",
   "networkMode": "awsvpc",
   "cpu": "256",
-  "memory": "512"
+  "memory": "1024"
 }


### PR DESCRIPTION
Some paketo-buildpacks versions have changed, which might be triggering errors in the deployment to staging. This is a speculative patch pending a proper investigation into how we can control those versions (and indeed whether they are the root cause for the memory exception logs noted in the failed deployments).

TIS21-4667