### PR TITLE
chore: upgrade sentry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
   testAnnotationProcessor("org.mapstruct:mapstruct-processor:${mapstructVersion}")
 
   // Sentry reporting
-  val sentryVersion = "7.4.0"
-  implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")
+  val sentryVersion = "7.6.0"
+  implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
   implementation("io.sentry:sentry-logback:$sentryVersion")
 
   implementation("io.awspring.cloud:spring-cloud-aws-starter-s3")


### PR DESCRIPTION
Sentry should use a different dependency for Spring Boot 3 compatibility.

TIS21-SHED