### PR TITLE
test: expect two digit day of month

### DIFF
--- a/src/test/java/uk/nhs/hee/tis/trainee/ndw/service/DataLakeFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/ndw/service/DataLakeFacadeTest.java
@@ -46,6 +46,7 @@ class DataLakeFacadeTest {
     ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
     int year = now.getYear();
     String month = String.format("%02d", now.getMonthValue());
+    String day = String.format("%02d", now.getDayOfMonth());
 
     InOrder orderVerifier = inOrder(directoryClient);
     orderVerifier.verify(directoryClient)
@@ -53,7 +54,7 @@ class DataLakeFacadeTest {
     orderVerifier.verify(directoryClient)
         .createSubdirectoryIfNotExists("month=" + year + month);
     orderVerifier.verify(directoryClient)
-        .createSubdirectoryIfNotExists("day=" + year + month + now.getDayOfMonth());
+        .createSubdirectoryIfNotExists("day=" + year + month + day);
   }
 
   @Test


### PR DESCRIPTION
Expect a double digit day of month for sub directory creation in test "shouldCreateYearMonthDaySubDirectories()", to fix the broken test: https://github.com/Health-Education-England/tis-trainee-ndw-exporter/actions/runs/11662489949/job/32468952721

The test failed as it was actually creating sub directory "20241104",
but expected "2024114" in the test
