### PR TITLE
fix: remove message converter bean

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.5.1"
+version = "1.5.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/ndw/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/ndw/config/ApplicationConfiguration.java
@@ -21,12 +21,9 @@
 
 package uk.nhs.hee.tis.trainee.ndw.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
-import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -38,18 +35,5 @@ public class ApplicationConfiguration {
   @Bean
   RestTemplate restTemplate(RestTemplateBuilder builder) {
     return builder.build();
-  }
-
-  /**
-   * Create a message converter bean with an object mapper.
-   *
-   * @param objectMapper The object mapper to set.
-   * @return The created message converter.
-   */
-  @Bean
-  public MessageConverter messageConverter(ObjectMapper objectMapper) {
-    var converter = new MappingJackson2MessageConverter();
-    converter.setObjectMapper(objectMapper);
-    return converter;
   }
 }


### PR DESCRIPTION
Since version `3.2.0` the Spring Cloud AWS starter for SQS autoconfigured a message converter, as a result the bean configured in ApplicationConfiguration is no longer needed.

NO-TICKET