### PR TITLE
chore(ltft): rename LTFT update queue

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -38,7 +38,7 @@
         },
         {
           "name": "NDW_LTFT_FORM_QUEUE_URL",
-          "valueFrom": "/tis/trainee/ndw/${environment}/queue-url/ltft/status-update"
+          "valueFrom": "/tis/trainee/ndw/${environment}/queue-url/ltft/update"
         },
         {
           "name": "NOTIFICATION_QUEUE_URL",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.6.0"
+version = "1.6.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
The LTFT status update queue has been renamed to account for it being used for both status and assigned admin updates.

TIS21-7082
TIS21-7087